### PR TITLE
more labeled video options during inference

### DIFF
--- a/lightning_pose_app/ui/project.py
+++ b/lightning_pose_app/ui/project.py
@@ -670,10 +670,12 @@ def _render_streamlit_fn(state: AppState):
             state.st_upload_existing_project_zippath = filepath
             enter_data = True
             st_mode = CREATE_STR
-        st.caption("If your zip file is larger than the 200MB limit, see the [FAQ]"
-                   "(https://pose-app.readthedocs.io/en/latest/source/faqs.html#faq-upload-limit)",
-                   unsafe_allow_html=True)
-                   
+        st.caption(
+            "If your zip file is larger than the 200MB limit, see the [FAQ]"
+            "(https://pose-app.readthedocs.io/en/latest/source/faqs.html#faq-upload-limit)",
+            unsafe_allow_html=True,
+        )
+
     if state.st_error_flag:
         st.markdown(state.st_error_msg, unsafe_allow_html=True)
         enter_data = False

--- a/lightning_pose_app/utilities.py
+++ b/lightning_pose_app/utilities.py
@@ -1,5 +1,4 @@
 import cv2
-import glob
 from lightning.app.frontend import StreamlitFrontend as LitStreamlitFrontend
 import logging
 import math


### PR DESCRIPTION
When running inference using an already-trained model, users can now select to export a labeled movie using the entire video and/or a 30 second clip that contains the highest motion energy in the predictions.